### PR TITLE
extract constants

### DIFF
--- a/src/main/java/com/doanduyhai/azure/spring_config/AzureEnvironmentPostProcessor.java
+++ b/src/main/java/com/doanduyhai/azure/spring_config/AzureEnvironmentPostProcessor.java
@@ -3,6 +3,8 @@
 
 package com.doanduyhai.azure.spring_config;
 
+import static com.doanduyhai.azure.spring_config.Constants.AZURE_TABLE_ENABLED_KEY;
+import static com.doanduyhai.azure.spring_config.Constants.AZURE_KEYVAULT_ENABLED_KEY;
 import static com.doanduyhai.azure.spring_config.azure_table.AzureTableProperties.CONNECTION_STRING_KEYVAUL_SECRET_NAME_PATTERN;
 import static com.doanduyhai.azure.spring_config.utils.Validator.validateTrue;
 import static java.lang.String.format;
@@ -33,7 +35,6 @@ public class AzureEnvironmentPostProcessor implements EnvironmentPostProcessor, 
 
     public static final int DEFAULT_ORDER = ConfigFileApplicationListener.DEFAULT_ORDER + 1;
     private int order = DEFAULT_ORDER;
-
 
     private static final DeferredLog logger = new DeferredLog();
 
@@ -89,14 +90,14 @@ public class AzureEnvironmentPostProcessor implements EnvironmentPostProcessor, 
                 true);
 
         if (tableEnabled) {
-            validateTrue(isKeyVaultEnabled(environment), "If 'azure.table.enabled' = true then 'azure.keyvault.enabled' should be true and the key vault configured properly");
+            validateTrue(isKeyVaultEnabled(environment), format("If '%s' = true then '%s' should be true and the key vault configured properly", AZURE_TABLE_ENABLED_KEY, AZURE_KEYVAULT_ENABLED_KEY));
             String storageAccountNameProperty = AzureTableProperties.getPropertyName(AzureTableProperties.Property.STORAGE_ACCOUNT_NAME);
             String storageAccountName = environment.getProperty(storageAccountNameProperty);
-            validateTrue(StringUtils.isNotBlank(storageAccountName), format("If 'azure.table.enabled' = true, then you should provide the property '%s'", storageAccountNameProperty));
+            validateTrue(StringUtils.isNotBlank(storageAccountName), format("If '%s' = true, then you should provide the property '%s'", AZURE_TABLE_ENABLED_KEY, storageAccountNameProperty));
 
             String tableNameProperty = AzureTableProperties.getPropertyName(AzureTableProperties.Property.TABLE_NAME);
             String tableName = environment.getProperty(tableNameProperty);
-            validateTrue(StringUtils.isNotBlank(tableName), format("If 'azure.table.enabled' = true, then you should provide the property '%s'", tableNameProperty));
+            validateTrue(StringUtils.isNotBlank(tableName), format("If '%s' = true, then you should provide the property '%s'", AZURE_TABLE_ENABLED_KEY, tableNameProperty));
 
             String keyVaultSecretName = format(CONNECTION_STRING_KEYVAUL_SECRET_NAME_PATTERN, storageAccountName);
             String tableConnectionString = keyVaultHelper.getKeyVaultSecret(keyVaultSecretName);

--- a/src/main/java/com/doanduyhai/azure/spring_config/Constants.java
+++ b/src/main/java/com/doanduyhai/azure/spring_config/Constants.java
@@ -11,4 +11,8 @@ public class Constants {
 
     public static final long DEFAULT_REFRESH_INTERVAL_MS = 1800000L;
 
+    public static final String AZURE_TABLE_ENABLED_KEY = "azure.table.enabled";
+    public static final String AZURE_KEYVAULT_ENABLED_KEY = "azure.keyvault.enabled";
+    public static final String AZURE_KEYVAULT_URI = "azure.keyvault.uri";
+
 }

--- a/src/main/java/com/doanduyhai/azure/spring_config/azure_table/PropertyValueDao.java
+++ b/src/main/java/com/doanduyhai/azure/spring_config/azure_table/PropertyValueDao.java
@@ -4,7 +4,6 @@ import com.microsoft.azure.storage.table.DynamicTableEntity;
 
 public class PropertyValueDao extends AzureTableDao<DynamicTableEntity> {
 
-
     public PropertyValueDao(String storageConnectionString, String tableName) {
         super(DynamicTableEntity.class, storageConnectionString, tableName);
     }

--- a/src/main/java/com/doanduyhai/azure/spring_config/keyvault/KeyVaultEnvironmentProcessor.java
+++ b/src/main/java/com/doanduyhai/azure/spring_config/keyvault/KeyVaultEnvironmentProcessor.java
@@ -3,9 +3,7 @@
 
 package com.doanduyhai.azure.spring_config.keyvault;
 
-import static com.doanduyhai.azure.spring_config.Constants.AZURE_KEYVAULT_PROPERTYSOURCE_NAME;
-import static com.doanduyhai.azure.spring_config.Constants.AZURE_SPRING_KEY_VAULT;
-import static com.doanduyhai.azure.spring_config.Constants.DEFAULT_REFRESH_INTERVAL_MS;
+import static com.doanduyhai.azure.spring_config.Constants.*;
 import static java.lang.String.format;
 import static org.springframework.core.env.StandardEnvironment.SYSTEM_ENVIRONMENT_PROPERTY_SOURCE_NAME;
 
@@ -45,7 +43,7 @@ public class KeyVaultEnvironmentProcessor {
         this.environment = environment;
         Validator.validateNotNull(environment, "Spring configurable environment");
         vaultUri = getPropertyValue(Property.URI);
-        Validator.validateNotBlank(vaultUri, "azure.keyvault.uri");
+        Validator.validateNotBlank(vaultUri, AZURE_KEYVAULT_URI);
         secretClient = new SecretClientBuilder()
                 .vaultUrl(vaultUri)
                 .credential(MSI_TOKEN_CREDENTIALS)


### PR DESCRIPTION
Extract 2 constants: `AZURE_TABLE_ENABLED_KEY` and `AZURE_KEYVAULT_ENABLED_KEY`

Why are you using `Boolean` instead of `boolean` into `AzureTableProperties` for variables `enabled` and `name`?

Why does `AzureTableOperation.getProperty()` return null? Can't you use `Optional` instead?

Is it possible to list all variables into `Constants` (ex: PREFIX = "azure.table", AzureTableProperties)? It would be easier to list all possible configurations.

